### PR TITLE
Update urls.py

### DIFF
--- a/fileupload/urls.py
+++ b/fileupload/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 from fileupload.views import PictureCreateView, PictureDeleteView
 
 urlpatterns = patterns('',


### PR DESCRIPTION
django.conf.urls.defaults will be removed. The functions include(), patterns() and url() plus handler404, handler500, are now available through django.conf.urls .
