### PR TITLE
Update requirement.txt. not compatible with Django 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django
+django==1.5
 pillow


### PR DESCRIPTION
not compatible with Django 1.6 Because of this
Traceback (most recent call last):
  File "manage.py", line 2, in <module>
    from django.core.management import execute_manager
ImportError: cannot import name execute_manager

"the deprecation policy that means that the code for execute_manager has been completely removed in 1.6. If you are seeing this import error then the version of Satchmo you are using has not been updated to be compatible with Django 1.6."

ref: http://stackoverflow.com/questions/18048232/satchmo-clonesatchmo-py-importerror-cannot-import-name-execute-manager
