### PR TITLE
Fix requirements.txt: Setting django version to 1.9 and pillow to 5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django
-pillow
+django==1.9
+pillow==5.0.0


### PR DESCRIPTION
Adding libraries versions to requirements.txt