### PR TITLE
Add trailing slashes for newer versions of Django (default settings)

### DIFF
--- a/fileupload/templates/fileupload/picture_basic_form.html
+++ b/fileupload/templates/fileupload/picture_basic_form.html
@@ -38,11 +38,11 @@
     <h1>Django jQuery File Upload Demo</h1>
     <h2 class="lead">Basic version</h2>
     <ul class="nav nav-tabs">
-        <li class="active"><a href="/upload/basic">Basic</a></li>
-        <li><a href="/upload/basic/plus">Basic Plus</a></li>
-        <li><a href="/upload/new">Basic Plus UI</a></li>
-        <li><a href="/upload/angular">AngularJS</a></li>
-        <li><a href="/upload/jquery-ui">jQuery UI</a></li>
+        <li class="active"><a href="/upload/basic/">Basic</a></li>
+        <li><a href="/upload/basic/plus/">Basic Plus</a></li>
+        <li><a href="/upload/new/">Basic Plus UI</a></li>
+        <li><a href="/upload/angular/">AngularJS</a></li>
+        <li><a href="/upload/jquery-ui/">jQuery UI</a></li>
     </ul>
     <br>
     <blockquote>

--- a/fileupload/templates/fileupload/picture_basicplus_form.html
+++ b/fileupload/templates/fileupload/picture_basicplus_form.html
@@ -38,11 +38,11 @@
     <h1>Django jQuery File Upload Demo</h1>
     <h2 class="lead">Basic Plus version</h2>
     <ul class="nav nav-tabs">
-        <li><a href="/upload/basic">Basic</a></li>
-        <li class="active"><a href="/upload/basic/plus">Basic Plus</a></li>
-        <li><a href="/upload/new">Basic Plus UI</a></li>
-        <li><a href="/upload/angular">AngularJS</a></li>
-        <li><a href="/upload/jquery-ui">jQuery UI</a></li>
+        <li><a href="/upload/basic/">Basic</a></li>
+        <li class="active"><a href="/upload/basic/plus/">Basic Plus</a></li>
+        <li><a href="/upload/new/">Basic Plus UI</a></li>
+        <li><a href="/upload/angular/">AngularJS</a></li>
+        <li><a href="/upload/jquery-ui/">jQuery UI</a></li>
     </ul>
     <br>
     <blockquote>

--- a/fileupload/templates/fileupload/picture_form.html
+++ b/fileupload/templates/fileupload/picture_form.html
@@ -6,11 +6,11 @@
     <h1>Django jQuery File Upload Demo</h1>
     <h2 class="lead">Basic Plus UI version</h2>
     <ul class="nav nav-tabs">
-        <li><a href="/upload/basic">Basic</a></li>
-        <li><a href="/upload/basic/plus">Basic Plus</a></li>
+        <li><a href="/upload/basic/">Basic</a></li>
+        <li><a href="/upload/basic/plus/">Basic Plus</a></li>
         <li class="active"><a href="/upload/new/">Basic Plus UI</a></li>
-        <li><a href="/upload/angular">AngularJS</a></li>
-        <li><a href="/upload/jquery-ui">jQuery UI</a></li>
+        <li><a href="/upload/angular/">AngularJS</a></li>
+        <li><a href="/upload/jquery-ui/">jQuery UI</a></li>
     </ul>
     <br>
     <blockquote>

--- a/fileupload/templates/fileupload/picture_jquery_form.html
+++ b/fileupload/templates/fileupload/picture_jquery_form.html
@@ -82,11 +82,11 @@
     </select>
 </form>
 <ul class="navigation">
-    <li><a href="/upload/basic">Basic</a></li>
-    <li><a href="/upload/basic/plus">Basic Plus</a></li>
-    <li><a href="/upload/new">Basic Plus UI</a></li>
-    <li><a href="/upload/angular">AngularJS</a></li>
-    <li class="active"><a href="/upload/jquery-ui">jQuery UI</a></li>
+    <li><a href="/upload/basic/">Basic</a></li>
+    <li><a href="/upload/basic/plus/">Basic Plus</a></li>
+    <li><a href="/upload/new/">Basic Plus UI</a></li>
+    <li><a href="/upload/angular/">AngularJS</a></li>
+    <li class="active"><a href="/upload/jquery-ui/">jQuery UI</a></li>
 </ul>
 <blockquote>
     <p>File Upload widget with multiple file selection, drag&amp;drop support, progress bars, validation and preview images, audio and video for jQuery UI.<br>


### PR DESCRIPTION
I've added trailing slashes to the links in the templates so that users can navigate between them again - this is broken by default settings in newer versions of Django (requires / on the end and the project is not set to default to redirect).